### PR TITLE
Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse/components/topic-selector.js.es6
+++ b/assets/javascripts/discourse/components/topic-selector.js.es6
@@ -1,7 +1,7 @@
 import { isEmpty } from "@ember/utils";
 import { next } from "@ember/runloop";
 import Component from "@ember/component";
-import discourseDebounce from "discourse/lib/debounce";
+import debounce from "discourse/plugins/projects/lib/debounce";
 import { searchForTerm } from "discourse/lib/search";
 import { observes } from "discourse-common/utils/decorators";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -72,42 +72,48 @@ export default Component.extend({
     this.set("loading", false);
   },
 
-  search: discourseDebounce(function(title) {
-    if (!this.element || this.isDestroying || this.isDestroyed || isEmpty(title)) {
-      return;
-    }
-
-    if (isEmpty(title) && isEmpty(this.additionalFilters)) {
-      this.setProperties({ topics: null, loading: false });
-      return;
-    }
-
-    const currentTopicId = this.currentTopicId;
-    const selectedTopics = this.selectedTopics;
-    const titleWithFilters = `${title} ${this.additionalFilters}`;
-    let searchParams = {};
-
-    if (!isEmpty(title)) {
-      searchParams.typeFilter = "topic";
-      searchParams.restrictToArchetype = "regular";
-      searchParams.searchForId = true;
-    }
-
-    searchForTerm(titleWithFilters, searchParams).then(results => {
-      if (results && results.posts && results.posts.length > 0) {
-        const store = Discourse.__container__.lookup("service:store");
-        const topicMap = [];
-        results.posts.mapBy("topic").filter(t => t.id !== currentTopicId)
-        .filter(t =>selectedTopics.every(st => t.id !== st.id)).forEach(t => (topicMap.push(store.createRecord("topic", t))));
-        this.set(
-          "topics",
-          topicMap
-        );
-      } else {
-        this.setProperties({ topics: null, loading: false });
-      }
-    });
-  }, 300),
+  search(title) { 
+    debounce(
+      this,
+      function() {
+        if (!this.element || this.isDestroying || this.isDestroyed || isEmpty(title)) {
+          return;
+        }
+    
+        if (isEmpty(title) && isEmpty(this.additionalFilters)) {
+          this.setProperties({ topics: null, loading: false });
+          return;
+        }
+    
+        const currentTopicId = this.currentTopicId;
+        const selectedTopics = this.selectedTopics;
+        const titleWithFilters = `${title} ${this.additionalFilters}`;
+        let searchParams = {};
+    
+        if (!isEmpty(title)) {
+          searchParams.typeFilter = "topic";
+          searchParams.restrictToArchetype = "regular";
+          searchParams.searchForId = true;
+        }
+    
+        searchForTerm(titleWithFilters, searchParams).then(results => {
+          if (results && results.posts && results.posts.length > 0) {
+            const store = Discourse.__container__.lookup("service:store");
+            const topicMap = [];
+            results.posts.mapBy("topic").filter(t => t.id !== currentTopicId)
+            .filter(t =>selectedTopics.every(st => t.id !== st.id)).forEach(t => (topicMap.push(store.createRecord("topic", t))));
+            this.set(
+              "topics",
+              topicMap
+            );
+          } else {
+            this.setProperties({ topics: null, loading: false });
+          }
+        });
+      },
+      300
+    )
+  },
 
   actions: {
     //TODO output as ids in action

--- a/assets/javascripts/discourse/lib/debounce.js.es6
+++ b/assets/javascripts/discourse/lib/debounce.js.es6
@@ -1,0 +1,6 @@
+import discourseDebounce from "discourse-common/lib/debounce";
+import { debounce } from "@ember/runloop";
+
+// TODO: Remove this file and use discouseDebounce after the 2.7 release.
+const debounceFunction = discourseDebounce || debounce;
+export default debounceFunction;

--- a/assets/javascripts/initializers/create.js.es6
+++ b/assets/javascripts/initializers/create.js.es6
@@ -1,7 +1,7 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { default as computed, observes, on } from 'ember-addons/ember-computed-decorators';
 import Composer from 'discourse/models/composer';
-import { debounce } from "@ember/runloop";
+import debounce from "discourse/plugins/projects/lib/debounce";
 import { later } from "@ember/runloop";
 import { bed_block_format, begin_format,duration_format,end_format } from '../discourse/lib/utils'
 import { once } from "@ember/runloop";


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.